### PR TITLE
Added encoding utf-8 to file atom.xml

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -336,7 +336,7 @@ def generate_archive_pages(app):
                  updated=post.update, published=post.date)
 
     with open(feed_path, 'w') as out:
-        out.write(feed.to_string())
+        out.write(feed.to_string().encode('utf-8'))
 
 
 


### PR DESCRIPTION
Hi Ahmet, this change fixes a bug which happened when ablog tried to generate the `atom.xml` file for my private blog (which contains non-ascii caracters). Now it gets generated correctly: http://luc.saffre-rumma.net/blog/atom.xml
