### PR TITLE
Corrected wrong redirect_wait variable to post_redirect_refresh

### DIFF
--- a/ablog/templates/redirect.html
+++ b/ablog/templates/redirect.html
@@ -1,9 +1,9 @@
 {%- extends "!layout.html" %}
 {%- block extrahead %}
   {{ super() }}
-  <meta http-equiv="refresh" content="{{ ablog.redirect_wait }}; url={{ pathto(redirect) }}" />
+  <meta http-equiv="refresh" content="{{ ablog.post_redirect_refresh }}; url={{ pathto(redirect) }}" />
 {% endblock %}
 
 {% block body %}
-  You are being redirected to <a href="{{ pathto(redirect) }}">{{ post.title }}</a> in {{ ablog.redirect_wait }} seconds;
+  You are being redirected to <a href="{{ pathto(redirect) }}">{{ post.title }}</a> in {{ ablog.post_redirect_refresh }} seconds;
 {% endblock %}


### PR DESCRIPTION
Done in redirect.html. ablog.redirect_wait didn't exist and automatic redirection was not working and showing a value of "None" in the HTML output