### PR TITLE
add line break after excerpts in postlisting

### DIFF
--- a/ablog/post.py
+++ b/ablog/post.py
@@ -438,6 +438,7 @@ def process_postlist(app, doctree, docname):
                     enode = enode.deepcopy()
                     enode.parent = bli.parent
                     bli.append(enode)
+                bli.append(nodes.line())
 
         node.replace_self(bl)
 


### PR DESCRIPTION
If excerpts are active in the .: _postlist directive (and more if you add an image) the text/image gets fast overlapped with the next post listing (next bullet point)

Adding a single break line after the excerpts really improves the visual ouput (it may be considered to make this an option ...)