### PR TITLE
escape filenames with git add -f ...

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -345,8 +345,8 @@ def ablog_deploy(website, message=None, github_pages=None,
 
         os.chdir(gitdir)
 
-        run("git add -f " +
-            " ".join([os.path.relpath(p) for p in git_add]), echo=True)
+        run("git add -f " + " ".join(['"{}"'.format(os.path.relpath(p))
+                                      for p in git_add]), echo=True)
         if not os.path.isfile('.nojekyll'):
             open('.nojekyll', 'w')
             run("git add -f .nojekyll")


### PR DESCRIPTION
When I run ``ablog deploy`` an error may occur if file name like this ``hello (World) .JPG``.

```python
/bin/sh: 1: Syntax error: "(" unexpected
Traceback (most recent call last):
  File "/home/uralbash/.virtualenvs/blog/bin/ablog", line 9, in <module>
    load_entry_point('ablog==0.7.7', 'console_scripts', 'ablog')()
  File "/home/uralbash/Projects/package/ablog/ablog/commands.py", line 377, in ablog_main
    namespace.func(**namespace.__dict__)
  File "/home/uralbash/Projects/package/ablog/ablog/commands.py", line 349, in ablog_deploy
    " ".join([os.path.relpath(p) for p in git_add]), echo=True)
  File "/home/uralbash/.virtualenvs/blog/local/lib/python2.7/site-packages/invoke-0.10.1-py2.7.egg/invoke/runner.py", line 349, in run
    return runner.run(command, **kwargs)
  File "/home/uralbash/.virtualenvs/blog/local/lib/python2.7/site-packages/invoke-0.10.1-py2.7.egg/invoke/runner.py", line 153, in run
    raise Failure(result)
invoke.exceptions.Failure: Command execution failure!

Exit code: 2

Stderr:

/bin/sh: 1: Syntax error: "(" unexpected
```