### PR TITLE
Overwrites commit when deploy

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -292,6 +292,8 @@ def ablog_post(filename, title=None, **kwargs):
     help="environment variable name storing GitHub access token")
 @arg('--push-quietly', dest='push_quietly', action='store_true', default=False,
     help="be more quiet when pushing changes")
+@arg('-f', dest='push_force', action='store_true', default=False,
+    help="owerwrites last commit, as 'commit --amend' and 'push -f'")
 @arg('-m', dest='message', type=str, help="commit message")
 @arg('-g', dest='github_pages', type=str,
     help="GitHub username for deploying to GitHub pages")
@@ -300,9 +302,7 @@ def ablog_post(filename, title=None, **kwargs):
     description="Path options can be set in conf.py. "
     "Default values of paths are relative to conf.py.")
 def ablog_deploy(website, message=None, github_pages=None,
-    push_quietly=False, github_token=None, **kwargs):
-
-    from shutil import rmtree
+    push_quietly=False, push_force=False, github_token=None, **kwargs):
 
     confdir = find_confdir()
     conf = read_conf(confdir)
@@ -361,7 +361,10 @@ def ablog_deploy(website, message=None, github_pages=None,
             open('.nojekyll', 'w')
             run("git add -f .nojekyll")
 
-        run('git commit -m "{}"'.format(message or 'Updates.', echo=True))
+        commit = 'git commit -m "{}"'.format(message or 'Updates.')
+        if push_force:
+            commit += ' --amend'
+        run(commit, echo=True)
 
         if github_token:
             with open(os.path.join(gitdir, '.git/credentials'), 'w') as out:
@@ -371,6 +374,8 @@ def ablog_deploy(website, message=None, github_pages=None,
         push = 'git push'
         if push_quietly:
             push += ' -q'
+        if push_force:
+            push += ' -f'
         push += ' origin master'
         run(push, echo=True)
 

--- a/docs/manual/ablog-commands.rst
+++ b/docs/manual/ablog-commands.rst
@@ -123,23 +123,24 @@ Running ``ablog deploy`` will push your website to GitHub.
 
 ::
 
-  $ ablog deploy -h
-  usage: ablog deploy [-h] [-g GITHUB_PAGES] [-m MESSAGE]
-                      [--github-token GITHUB_TOKEN] [--push-quietly]
-                      [-w WEBSITE]
+   ablog deploy -h
+   usage: ablog deploy [-h] [-w WEBSITE] [-g GITHUB_PAGES] [-m MESSAGE] [-f]
+                       [--push-quietly] [--github-token GITHUB_TOKEN]
 
-  Path options can be set in conf.py. Default values of paths are relative to
-  conf.py.
+   Path options can be set in conf.py. Default values of paths are relative to
+   conf.py.
 
-  optional arguments:
-    -h, --help            show this help message and exit
-    -g GITHUB_PAGES       GitHub username for deploying to GitHub pages
-    -m MESSAGE            commit message
-    --github-token GITHUB_TOKEN
-                          environment variable name storing GitHub access token
-    --push-quietly        be more quiet when pushing changes
-    -w WEBSITE            path for website, default is _website when
-                          `ablog_website` is not set in conf.py
+   optional arguments:
+     -h, --help            show this help message and exit
+     -w WEBSITE            path for website, default is _website when
+                           `ablog_website` is not set in conf.py
+     -g GITHUB_PAGES       GitHub username for deploying to GitHub pages
+     -m MESSAGE            commit message
+     -f                    owerwrites last commit, as 'commit --amend' and 'push
+                           -f'
+     --push-quietly        be more quiet when pushing changes
+     --github-token GITHUB_TOKEN
+                           environment variable name storing GitHub access token
 
 Create a Post
 -------------


### PR DESCRIPTION
Each commit increases the disk space occupied. It is not necessary for hosting on github-pages. Option ``-f`` allows to overwrite last commit like ``git commit --amend`` and ``git push -f``.

It works like that:
```bash
ablog deploy -f
```