### PR TITLE
Provide extension version number to Sphinx

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -73,6 +73,8 @@ def setup(app):
     locale_dir = os.path.join(pkgdir, 'locale')
     app.config.locale_dirs.append(locale_dir)
 
+    return {'version': __version__}   # identifies the version of our extension
+
 
 def get_html_templates_path():
     """Return path to ABlog templates folder."""


### PR DESCRIPTION
In particular, the version number will show up in the Sphinx log. So instead of:

```
# Sphinx version: 1.3.5
[...]
# Loaded extensions:
#   ablog (unknown version) from s:\documents\github\ablog\ablog\__init__.py
[...]
```

you get:

```
# Sphinx version: 1.3.5
[...]
# Loaded extensions:
#   ablog (0.8.2) from s:\documents\github\ablog\ablog\__init__.py
[...]
```