### PR TITLE
Disable comments for the current post

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -80,9 +80,9 @@ CONFIG = [
     ('post_redirect_refresh', 5, True),
     ('post_always_section', False, True),
 
-    ('disqus_shortname', None, True),
-    ('disqus_drafts', False, True),
-    ('disqus_pages', False, True),
+    ('ablog_disqus_shortname', None, True),
+    ('ablog_disqus_drafts', False, True),
+    ('ablog_disqus_pages', False, True),
 ]
 
 
@@ -329,6 +329,7 @@ class Post(BlogPageMixin):
         self.order = info['order']
         self.date = date = info['date']
         self.update = info['update']
+        self.nocomments = info['nocomments']
         self.published = date and date < TOMORROW
         self.draft = not self.published
         self._title = info['title']

--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -80,9 +80,9 @@ CONFIG = [
     ('post_redirect_refresh', 5, True),
     ('post_always_section', False, True),
 
-    ('ablog_disqus_shortname', None, True),
-    ('ablog_disqus_drafts', False, True),
-    ('ablog_disqus_pages', False, True),
+    ('disqus_shortname', None, True),
+    ('disqus_drafts', False, True),
+    ('disqus_pages', False, True),
 ]
 
 

--- a/ablog/post.py
+++ b/ablog/post.py
@@ -64,6 +64,7 @@ class PostDirective(Directive):
         'image': int,
         'excerpt': int,
         'exclude': directives.flag,
+        'nocomments': directives.flag,
     }
 
     def run(self):
@@ -85,6 +86,7 @@ class PostDirective(Directive):
         node['image'] = self.options.get('image', None)
         node['excerpt'] = self.options.get('excerpt', None)
         node['exclude'] = 'exclude' in self.options
+        node['nocomments'] = 'nocomments' in self.options
         return [node]
 
 
@@ -337,6 +339,7 @@ def process_posts(app, doctree):
             'location': node['location'],
             'language': node['language'],
             'redirect': node['redirect'],
+            'nocomments': node['nocomments'],
             'image': node['image'],
             'exclude': node['exclude'],
             'doctree': section_copy

--- a/ablog/templates/page.html
+++ b/ablog/templates/page.html
@@ -26,7 +26,11 @@
   {% if pagename in ablog %}
     {% include "postnavy.html" %}
   {% endif %}
-  {% if ablog.disqus_shortname and ablog.blog_baseurl and ((pagename in ablog and (ablog[pagename].published or ablog.disqus_drafts)) or (not pagename in ablog and ablog.disqus_pages)) %}
+  {% if ablog.disqus_shortname and ablog.blog_baseurl and
+        (not ablog[pagename].nocomments) and
+        ((pagename in ablog and (ablog[pagename].published or
+          ablog.disqus_drafts)) or
+         (not pagename in ablog and ablog.disqus_pages)) %}
     <div class="section">
     <h2>Comments</h2>
     <div id="disqus_thread"></div>

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -29,6 +29,7 @@ following directive:
         :redirect: blog/old-page-name-for-the-post
         :excerpt: 2
         :image: 1
+        :nocoments:
 
 
    **Drafts & Posts**
@@ -67,6 +68,11 @@ following directive:
    using ``:redirect:`` option.  It takes a comma separated list of paths,
    relative to the root folder.  The redirect page waits for
    :confval:`post_redirect_refresh` seconds before redirection occurs.
+
+   **Disable comments**
+
+   You can disable comments for the current post using the ``:nocomment:``
+   option. Currently there is no way to disable comments in a specific page.
 
    **Excerpts & Images**
 

--- a/docs/manual/posting-and-listing.rst
+++ b/docs/manual/posting-and-listing.rst
@@ -71,7 +71,7 @@ following directive:
 
    **Disable comments**
 
-   You can disable comments for the current post using the ``:nocomment:``
+   You can disable comments for the current post using the ``:nocomments:``
    option. Currently there is no way to disable comments in a specific page.
 
    **Excerpts & Images**


### PR DESCRIPTION
User can now disable comments for the current post.

- Added a `:nocomments:` option to the `.. post::` directive
- Added documentation for `:nocomments:` option
- Added line breaks in `ablog/templates/page.html` to improve
  readability

Example:

```rst
.. post:: 15 Apr, 2013
   :tags: tips, ablog, directive
   :category: Example, How To
   :author: Ahmet, Durden
   :nocomments:
```