### PR TITLE
Fix "address already in use" on second "serve"

### DIFF
--- a/ablog/__init__.py
+++ b/ablog/__init__.py
@@ -8,7 +8,7 @@ from .post import (PostDirective, PostListDirective, UpdateDirective,
                    generate_archive_pages, generate_atom_feeds,
                    missing_reference)
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 
 def anchor(post):

--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -199,6 +199,9 @@ def ablog_serve(website=None, port=8000, view=True, rebuild=False,
 
     import webbrowser
 
+    # to allow restarting the server in short succession
+    socketserver.TCPServer.allow_reuse_address = True
+
     Handler = server.SimpleHTTPRequestHandler
     httpd = socketserver.TCPServer(("", port), Handler)
 


### PR DESCRIPTION
Fixes #69
Kind of strange that TCPServer has such a strange API and can't clean up after itself normally...

On a side note, I've noticed that ablog/**init**.py has Windows line endings. Is there a reason for that?
