### PR TITLE
Change disqus src to avoid mixed content warnings

### DIFF
--- a/ablog/templates/postcard2.html
+++ b/ablog/templates/postcard2.html
@@ -58,7 +58,7 @@
     (function () {
     var s = document.createElement('script'); s.async = true;
     s.type = 'text/javascript';
-    s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+    s.src = '//' + disqus_shortname + '.disqus.com/count.js';
     (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
     }());
     </script>


### PR DESCRIPTION
Change the location of the disqus.com/count.js in
order to avoid mixed content warnings when serving
over SSL.
