### PR TITLE
tried to operate in a multi-language environment

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -19,7 +19,7 @@ def find_confdir():
 
     conf = join(confdir, 'conf.py')
 
-    if isfile(conf) and 'ablog' in open(conf).read():
+    if isfile(conf) and 'ablog' in open(conf, 'r', encoding='utf-8').read():
         return confdir
     else:
         sys.exit("Current directory and its parents doesn't "


### PR DESCRIPTION
When I build ablog project in Japanese environment I get UnicodeDecodeError.
I fixed the code so that no error occurs.

> (ablogtest) C:\repo\blog>ver
Microsoft Windows [Version 10.0.14393]

> (ablogtest)
 C:\repo\blog>python -V
Python 3.5.2

> (ablogtest) C:\repo\blog>pip freeze
ablog==0.8.4
alabaster==0.7.9
Babel==2.3.4
colorama==0.3.7
docutils==0.13.1
imagesize==0.7.1
invoke==0.14.0
Jinja2==2.9.4
MarkupSafe==0.23
Pygments==2.1.3
python-dateutil==2.6.0
pytz==2016.10
requests==2.12.5
six==1.10.0
snowballstemmer==1.2.1
Sphinx==1.5.1
Werkzeug==0.11.15

> (ablogtest)
 C:\repo\blog>ablog build
Traceback (most recent call last):
  File "C:\Python35\lib\runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python35\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\venv\ablogtest\Scripts\ablog.exe\__main__.py", line 9, in <module>
  File "c:\venv\ablogtest\lib\site-packages\ablog\commands.py", line 404, in ablog_main
    namespace.func(**namespace.__dict__)
  File "c:\venv\ablogtest\lib\site-packages\ablog\commands.py", line 119, in ablog_build
    confdir = find_confdir()
  File "c:\venv\ablogtest\lib\site-packages\ablog\commands.py", line 22, in find_confdir
    if isfile(conf) and 'ablog' in open(conf).read():
UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 637: illegal multibyte sequence

