### PR TITLE
Change default for fontawesome_link_cdn

### DIFF
--- a/ablog/blog.py
+++ b/ablog/blog.py
@@ -69,7 +69,7 @@ CONFIG = [
     ('blog_languages', {}, True),
     ('blog_default_language', None, True),
 
-    ('fontawesome_link_cdn', False, True),
+    ('fontawesome_link_cdn', None, True),
     ('fontawesome_included', False, True),
     ('fontawesome_css_file', '', True),
 


### PR DESCRIPTION
Refs https://github.com/writethedocs/www/issues/159 -- this complains when being set to a string, and should default to a blank string or `None` -- not 100% sure which. 

Fixes this error:

```
WARNING: The config value `fontawesome_link_cdn' has type `str', defaults to `bool'.
```