### PR TITLE
don't use fancy quotes in the conf.py template

### DIFF
--- a/ablog/start.py
+++ b/ablog/start.py
@@ -50,7 +50,7 @@ import alabaster
 # A path relative to the configuration directory for blog archive pages.
 #blog_path = 'blog'
 
-# The “title” for the blog, used in acthive pages.  Default is ``'Blog'``.
+# The "title" for the blog, used in active pages.  Default is ``'Blog'``.
 blog_title = u'%(project_str)s Blog'
 
 # Base URL for the website, required for generating feeds.


### PR DESCRIPTION
This is a three-character patch to partially fix #86 that prevented me from doing `ablog build` right after `ablog start` under Windows.

I'm still not quite sure what happened (When does Python assume a cp1252 encoding in the first place? If fancy quotes in a comment break the build, why are umlauts in `blog_title` working?) - but no matter what, I'm confident nobody is going to miss the fancy quotes.