### PR TITLE
fix(commands): Update command arguments so patterns works correctly

### DIFF
--- a/ablog/commands.py
+++ b/ablog/commands.py
@@ -171,7 +171,7 @@ def ablog_clean(website=None, doctrees=None, deep=False, **kwargs):
         print('Nothing to clean.')
 
 
-@arg('--patterns', dest='rebuild', action='store_false', default='*.rst;*.txt',
+@arg('--patterns', dest='patterns', default='*.rst;*.txt',
     help="patterns for triggering rebuilds")
 @arg('-r', dest='rebuild', action='store_true', default=False,
     help="rebuild when a file matching patterns change or get added")


### PR DESCRIPTION
The patterns argument does not work as is; it looks like a copy-n-paste error.